### PR TITLE
test: isolate provider manager from ambient OpenAI credentials

### DIFF
--- a/providers/test-manager.mjs
+++ b/providers/test-manager.mjs
@@ -1,4 +1,26 @@
 import assert from 'node:assert/strict';
 import { ProviderManager } from './manager.mjs';
-const manager = new ProviderManager('providers/manifest.json'); await manager.load();
-assert.equal(manager.list().length, 5); assert.equal(manager.list().find(provider => provider.id === 'local-openai-compatible').configured, true); await assert.rejects(manager.chat('openai', []), /OPENAI_API_KEY/); console.log('provider manager test passed');
+
+const originalOpenAiKey = process.env.OPENAI_API_KEY;
+delete process.env.OPENAI_API_KEY;
+
+try {
+  const manager = new ProviderManager('providers/manifest.json');
+  await manager.load();
+
+  assert.equal(manager.list().length, 5);
+  assert.equal(
+    manager.list().find(provider => provider.id === 'local-openai-compatible').configured,
+    true
+  );
+
+  await assert.rejects(manager.chat('openai', []), /OPENAI_API_KEY/);
+
+  console.log('provider manager test passed');
+} finally {
+  if (originalOpenAiKey === undefined) {
+    delete process.env.OPENAI_API_KEY;
+  } else {
+    process.env.OPENAI_API_KEY = originalOpenAiKey;
+  }
+}


### PR DESCRIPTION
The provider-manager test assumed `OPENAI_API_KEY` was absent from the developer environment.

On a machine with a real ambient key configured, `manager.chat('openai', [])` proceeded into a live provider request instead of exercising the intended missing-credential path. That produced an HTTP 401 and caused the test to fail.

This change temporarily removes `OPENAI_API_KEY` before constructing/loading `ProviderManager`, exercises the missing-key assertion, and restores the original environment value in `finally`.

This keeps the test deterministic and prevents it from making an unintended external provider request based on developer shell state.

Validation:
- `node providers/test-manager.mjs` — PASS with ambient `OPENAI_API_KEY` present
- `git diff --check` — PASS
- `npm test` — PASS through final AIDE daemon end-to-end smoke

Scope is intentionally limited to `providers/test-manager.mjs`.

Separate source-checkout findings around optional GGUF/runtime prerequisites and generated DAP evidence are intentionally not included in this change.